### PR TITLE
Update angular-disqus.js

### DIFF
--- a/src/angular-disqus.js
+++ b/src/angular-disqus.js
@@ -186,7 +186,6 @@
        */
       function loadCount(id) {
         setGlobals(id, $location.absUrl(), shortname);
-        addScriptTag(getShortname(), TYPE_EMBED);
         addScriptTag(getShortname(), TYPE_COUNT);
         getCount();
       }


### PR DESCRIPTION
Removing embed.js from loadcount to avoid appendChild on null object when only needing comment counts.
